### PR TITLE
Fix small typo in API IDs and listen paths, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tyk-chemas
+# tyk-schemas
 
 **JSON and YAML schemas for various json file types used by Tyk products. 
 You can use these schemas in your IDE or favourite editor to get autocompletion and validation of all your Tyk related configuration files.**

--- a/schema_apidef_full.json
+++ b/schema_apidef_full.json
@@ -7,7 +7,7 @@
     "default": {},
     "examples": [
         {
-            "api_id": "mynewpi",
+            "api_id": "mynewapi",
             "upstream_certificates": {},
             "use_keyless": true,
             "enable_coprocess_auth": false,
@@ -24,11 +24,11 @@
             "blacklisted_ips": [],
             "do_not_track": false,
             "name": "My Api",
-            "slug": "mynewpi",
+            "slug": "mynewapi",
             "proxy": {
                 "target_url": "http://httpbin.org",
                 "strip_listen_path": true,
-                "listen_path": "/mynewpi/",
+                "listen_path": "/mynewapi/",
                 "disable_strip_slash": true
             },
             "definition": {

--- a/schema_apidef_lean.json
+++ b/schema_apidef_lean.json
@@ -9,10 +9,10 @@
     "description": "The root schema comprises the entire JSON document.",
     "default": {
         "name": "My New Api",
-        "api_id": "mynewpi",
+        "api_id": "mynewapi",
         "org_id": "default",
         "proxy": {
-            "listen_path": "/mynewpi/",
+            "listen_path": "/mynewapi/",
             "target_url": "http://httpbin.org",
             "strip_listen_path": true,
             "preserve_host_header": true


### PR DESCRIPTION
Generated example JSON files and README have small typo. This PR updates it.